### PR TITLE
Make ICspProvider and IJhooseSecurityService services scoped 

### DIFF
--- a/.github/workflows/build-jhoose-security.yml
+++ b/.github/workflows/build-jhoose-security.yml
@@ -8,8 +8,8 @@ on:
   workflow_dispatch:
 
 env:
-  BUILD_NO: 2.4.0.${{ github.run_number }}  
-  BUILD_NO_PRE: 2.4.0-rc.${{ github.run_number }} 
+  BUILD_NO: 2.4.1.${{ github.run_number }}  
+  BUILD_NO_PRE: 2.4.1-rc.${{ github.run_number }} 
 
 jobs:
   build:

--- a/.github/workflows/build-jhoose-security.yml
+++ b/.github/workflows/build-jhoose-security.yml
@@ -8,8 +8,8 @@ on:
   workflow_dispatch:
 
 env:
-  BUILD_NO: 2.3.2.${{ github.run_number }}  
-  BUILD_NO_PRE: 2.3.2-rc.${{ github.run_number }} 
+  BUILD_NO: 2.4.0.${{ github.run_number }}  
+  BUILD_NO_PRE: 2.4.0-rc.${{ github.run_number }} 
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -275,3 +275,4 @@ X-API-Key: ...
  |2.2.2|Bug with response header cache not being cleared after a change.|
  |2.3.0| Added a new Dashboard; this gives a summary of any current issues and also allows you to search for historical issues.<br/> UI refresh and various bug fixes  |
  |2.3.1| Bug fixes |
+ |2.4.0| Added 'wasm-unsafe-eval' to the CSP Options<br/>Added missing options to default-src |

--- a/src/Jhoose.Security.Core/Jhoose.Security.Core.csproj
+++ b/src/Jhoose.Security.Core/Jhoose.Security.Core.csproj
@@ -9,7 +9,7 @@
 		<RepositoryUrl>https://github.com/andrewmarkham/contentsecuritypolicy</RepositoryUrl>
 		<ProjectUrl>https://github.com/andrewmarkham/contentsecuritypolicy</ProjectUrl>
 		-->
-		<Version>2.3.2.0</Version>
+		<Version>2.4.0.0</Version>
 		<Authors>Andrew Markham</Authors>
 		<Title>Jhoose Security Core</Title>
 		<Description>Core package used by the Jhoose Security module</Description>

--- a/src/Jhoose.Security.Core/Jhoose.Security.Core.csproj
+++ b/src/Jhoose.Security.Core/Jhoose.Security.Core.csproj
@@ -9,7 +9,7 @@
 		<RepositoryUrl>https://github.com/andrewmarkham/contentsecuritypolicy</RepositoryUrl>
 		<ProjectUrl>https://github.com/andrewmarkham/contentsecuritypolicy</ProjectUrl>
 		-->
-		<Version>2.4.0.0</Version>
+		<Version>2.4.1.0</Version>
 		<Authors>Andrew Markham</Authors>
 		<Title>Jhoose Security Core</Title>
 		<Description>Core package used by the Jhoose Security module</Description>

--- a/src/Jhoose.Security.Core/Models/CSP/CspOptions.cs
+++ b/src/Jhoose.Security.Core/Models/CSP/CspOptions.cs
@@ -11,6 +11,7 @@ namespace Jhoose.Security.Core.Models.CSP
             this.Self = false;
 
             this.UnsafeEval = false;
+            this.WasmUnsafeEval = false;
             this.UnsafeHashes = false;
             this.UnsafeInline = false;
             this.StrictDynamic = false;
@@ -21,6 +22,7 @@ namespace Jhoose.Security.Core.Models.CSP
         public bool Wildcard { get; set; }
         public bool Self { get; set; }
         public bool UnsafeEval { get; set; }
+        public bool WasmUnsafeEval { get; set; }
         public bool UnsafeHashes { get; set; }
         public bool UnsafeInline { get; set; }
         public bool StrictDynamic { get; set; }
@@ -40,6 +42,7 @@ namespace Jhoose.Security.Core.Models.CSP
             if (this.Self) sb.Append("'self' ");
 
             if (this.UnsafeEval) sb.Append("'unsafe-eval' ");
+            if (this.WasmUnsafeEval) sb.Append("'wasm-unsafe-eval' ");
             if (this.UnsafeHashes) sb.Append("'unsafe-hashes' ");
             if (this.UnsafeInline) sb.Append("'unsafe-inline' ");
             if (this.StrictDynamic) sb.Append("'strict-dynamic' ");
@@ -49,6 +52,6 @@ namespace Jhoose.Security.Core.Models.CSP
             return sb.ToString();
         }
 
-        public bool HasOptions => this.None | this.Wildcard | this.Self | this.UnsafeEval | this.UnsafeHashes | this.UnsafeInline | this.StrictDynamic | this.Nonce;
+        public bool HasOptions => this.None | this.Wildcard | this.Self | this.WasmUnsafeEval| this.UnsafeEval | this.UnsafeHashes | this.UnsafeInline | this.StrictDynamic | this.Nonce;
     }
 }

--- a/src/Jhoose.Security.Reporting/Database/ISqlHelper.cs
+++ b/src/Jhoose.Security.Reporting/Database/ISqlHelper.cs
@@ -13,6 +13,9 @@ namespace Jhoose.Security.Reporting.Database
                                                       IEnumerable<SqlParameter> parameters, 
                                                       Func<SqlDataReader, T>? readerAction = null,
                                                       int defaultReturnValue = -1);
+
+        Task<T?> ExecuteScalar<T>(string sqlCommand, params SqlParameter[] parameters);
+
         public SqlParameter CreateParameter<T>(string parameterName, DbType dbType, T value);
         //public SqlParameter CreateParameter(string parameterName, DbType dbType, int size);
     }

--- a/src/Jhoose.Security.Reporting/Database/SqlHelper.cs
+++ b/src/Jhoose.Security.Reporting/Database/SqlHelper.cs
@@ -27,6 +27,23 @@ namespace Jhoose.Security.Reporting.Database
             }
         }
 
+        public async Task<T?> ExecuteScalar<T>(string sqlCommand, params SqlParameter[] parameters)
+        {
+            try{
+                using var connection = new SqlConnection(options.ConnectionString);
+                connection.Open();
+                using var command = new SqlCommand(sqlCommand, connection);
+
+                command.Parameters.AddRange(parameters);
+                var result = await command.ExecuteScalarAsync();
+                return (T?)result;
+            } catch (Exception ex)
+            {
+                logger.LogError(ex, "Error while executing non query");
+                return default;
+            }
+        }
+
         public async Task<T?> ExecuteReader<T>(string sqlCommand, IEnumerable<SqlParameter>? parameters,Func<SqlDataReader, T>? readerAction = null)
         {
             T? results = default;

--- a/src/Jhoose.Security/DependencyInjection/SecurityExtensions.cs
+++ b/src/Jhoose.Security/DependencyInjection/SecurityExtensions.cs
@@ -57,9 +57,9 @@ namespace Jhoose.Security.DependencyInjection
 
 
             services.AddScoped<ICspPolicyRepository, StandardCspPolicyRepository>();
-            services.AddSingleton<ICspProvider, StandardCspProvider>();
+            services.AddScoped<ICspProvider, StandardCspProvider>();
             services.AddSingleton<ICacheManager, EpiserverCacheManager>();
-            services.AddSingleton<IJhooseSecurityService, JhooseSecurityService>();
+            services.AddScoped<IJhooseSecurityService, JhooseSecurityService>();
 
             services.AddScoped<IResponseHeadersRepository, StandardResponseHeadersRepository>();
             services.AddScoped<IAuthKeyService, DefaultAuthKeyService>();

--- a/src/Jhoose.Security/Jhoose.Security.csproj
+++ b/src/Jhoose.Security/Jhoose.Security.csproj
@@ -9,7 +9,7 @@
 		<RepositoryUrl>https://github.com/andrewmarkham/contentsecuritypolicy</RepositoryUrl>
 		<ProjectUrl>https://github.com/andrewmarkham/contentsecuritypolicy</ProjectUrl>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<Version>2.3.2.0</Version>
+		<Version>2.4.0.0</Version>
 		<Authors>Andrew Markham</Authors>
 		<Description>Interface to manage Content Security Policy and OWASP Recommended response headers</Description>
 		<Title>Jhoose Security</Title>
@@ -39,6 +39,8 @@
 			        New reporting Dashboard
 			2.3.1 - Bug fixes
 			2.3.2 - Fixed bug with CSP issues not being reported correctly.
+			2.4.0 - Added 'wasm-unsafe-eval' to the CSP Options
+			        Added missing options to default-src 
 		</ReleaseNotes>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<RestoreSources Condition=" '$(Configuration)' == 'Debug' ">

--- a/src/Jhoose.Security/Jhoose.Security.csproj
+++ b/src/Jhoose.Security/Jhoose.Security.csproj
@@ -9,7 +9,7 @@
 		<RepositoryUrl>https://github.com/andrewmarkham/contentsecuritypolicy</RepositoryUrl>
 		<ProjectUrl>https://github.com/andrewmarkham/contentsecuritypolicy</ProjectUrl>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<Version>2.4.0.0</Version>
+		<Version>2.4.1.0</Version>
 		<Authors>Andrew Markham</Authors>
 		<Description>Interface to manage Content Security Policy and OWASP Recommended response headers</Description>
 		<Title>Jhoose Security</Title>

--- a/src/Jhoose.Security/src/components/csp/CspOptions.tsx
+++ b/src/Jhoose.Security/src/components/csp/CspOptions.tsx
@@ -52,6 +52,11 @@ export function CspOptions(props: Props) {
                             setPolicyValue("unsafeEval");
                         }}>Unsafe Eval</Checkbox>
 
+                        <Checkbox disabled={options.none} checked={options.wasmUnsafeEval} onChange={() => {
+                            setPolicyValue("wasmUnsafeEval");
+                        }}>Wasm Unsafe Eval</Checkbox>
+
+
                         <Checkbox disabled={options.none} checked={options.unsafeHashes} onChange={() => {
                             setPolicyValue("unsafeHashes");
                         }}>Unsafe Hashes</Checkbox>

--- a/src/Jhoose.Security/src/components/csp/helpers.ts
+++ b/src/Jhoose.Security/src/components/csp/helpers.ts
@@ -13,6 +13,7 @@ export function getPolicyOptionsDisplay(policy: CspPolicy): string {
             v = policy.options.self ? v+= "'self' " : v;
 
             v = policy.options.unsafeEval ? v+= "'unsafe-eval' " : v;
+            v = policy.options.wasmUnsafeEval ? v+= "'wasm-unsafe-eval' " : v;
             v = policy.options.unsafeHashes ? v+= "'unsafe-hashes' " : v;
             v = policy.options.unsafeInline ? v+= "'unsafe-inline' " : v;
             v = policy.options.strictDynamic ? v+= "'strict-dynamic' " : v;
@@ -44,7 +45,7 @@ export function getSchemaSourceDisplay(policy: CspPolicy): string {
 
 export function isScriptPolicy(policy: CspPolicy): boolean{
 
-    if(policy.policyName === "script-src" || policy.policyName === "style-src") {
+    if(policy.policyName === "default-src" || policy.policyName === "script-src" || policy.policyName === "style-src") {
         return true;
     }        
 
@@ -52,7 +53,8 @@ export function isScriptPolicy(policy: CspPolicy): boolean{
 }
 
 export function getSandboxOptionsDisplay(policy: CspSandboxPolicy): string {
-    var v = `${policy.policyName} `;
+    //var v = `${policy.policyName} `;
+    var v = "";
     // sandboxOptions
     if (policy.sandboxOptions?.enabled ?? false) {
         v = policy.sandboxOptions?.allowDownloads ? v+= "allow-downloads " : v;

--- a/src/Jhoose.Security/src/components/csp/types/types.ts
+++ b/src/Jhoose.Security/src/components/csp/types/types.ts
@@ -25,7 +25,7 @@ export type SchemaSource = {
     wss?: boolean;
 }
 
-export type PolicyOptionName = "wildcard" | "none" | "self" | "unsafeEval" | "unsafeHashes" | "unsafeInline" | "strictDynamic" | "nonce";
+export type PolicyOptionName = "wildcard" | "none" | "self" | "wasmUnsafeEval" | "unsafeEval" | "unsafeHashes" | "unsafeInline" | "strictDynamic" | "nonce";
 
 export interface PolicyOptions extends Record<PolicyOptionName,boolean>{}
 


### PR DESCRIPTION
Make ICspProvider and IJhooseSecurityService services scoped instead of singleton to allow for unique dynamic nonce value per request.

Tested against the Demo site only after making some modifications to allow me to run demo site.

Further validation from plugin author required + release if this changes is OK.

PR also includes other changes from release/v2.4.0 which are not in main (unsure where this PR should target)