### PR TITLE
Make ICspProvider and IJhooseSecurityService services scoped instead …

### DIFF
--- a/.github/workflows/build-jhoose-security.yml
+++ b/.github/workflows/build-jhoose-security.yml
@@ -8,8 +8,8 @@ on:
   workflow_dispatch:
 
 env:
-  BUILD_NO: 2.4.0.${{ github.run_number }}  
-  BUILD_NO_PRE: 2.4.0-rc.${{ github.run_number }} 
+  BUILD_NO: 2.4.1.${{ github.run_number }}  
+  BUILD_NO_PRE: 2.4.1-rc.${{ github.run_number }} 
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -276,3 +276,4 @@ X-API-Key: ...
  |2.3.0| Added a new Dashboard; this gives a summary of any current issues and also allows you to search for historical issues.<br/> UI refresh and various bug fixes  |
  |2.3.1| Bug fixes |
  |2.4.0| Added 'wasm-unsafe-eval' to the CSP Options<br/>Added missing options to default-src |
+ |2.4.1| Make ICspProvider and IJhooseSecurityService request scoped so a unqiue dynamic nonce is generated per request |

--- a/src/Jhoose.Security.Core/Jhoose.Security.Core.csproj
+++ b/src/Jhoose.Security.Core/Jhoose.Security.Core.csproj
@@ -9,7 +9,7 @@
 		<RepositoryUrl>https://github.com/andrewmarkham/contentsecuritypolicy</RepositoryUrl>
 		<ProjectUrl>https://github.com/andrewmarkham/contentsecuritypolicy</ProjectUrl>
 		-->
-		<Version>2.4.0.0</Version>
+		<Version>2.4.1.0</Version>
 		<Authors>Andrew Markham</Authors>
 		<Title>Jhoose Security Core</Title>
 		<Description>Core package used by the Jhoose Security module</Description>

--- a/src/Jhoose.Security/DependencyInjection/SecurityExtensions.cs
+++ b/src/Jhoose.Security/DependencyInjection/SecurityExtensions.cs
@@ -57,9 +57,9 @@ namespace Jhoose.Security.DependencyInjection
 
 
             services.AddScoped<ICspPolicyRepository, StandardCspPolicyRepository>();
-            services.AddSingleton<ICspProvider, StandardCspProvider>();
+            services.AddScoped<ICspProvider, StandardCspProvider>();
             services.AddSingleton<ICacheManager, EpiserverCacheManager>();
-            services.AddSingleton<IJhooseSecurityService, JhooseSecurityService>();
+            services.AddScoped<IJhooseSecurityService, JhooseSecurityService>();
 
             services.AddScoped<IResponseHeadersRepository, StandardResponseHeadersRepository>();
             services.AddScoped<IAuthKeyService, DefaultAuthKeyService>();

--- a/src/Jhoose.Security/Jhoose.Security.csproj
+++ b/src/Jhoose.Security/Jhoose.Security.csproj
@@ -9,7 +9,7 @@
 		<RepositoryUrl>https://github.com/andrewmarkham/contentsecuritypolicy</RepositoryUrl>
 		<ProjectUrl>https://github.com/andrewmarkham/contentsecuritypolicy</ProjectUrl>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<Version>2.4.0.0</Version>
+		<Version>2.4.1.0</Version>
 		<Authors>Andrew Markham</Authors>
 		<Description>Interface to manage Content Security Policy and OWASP Recommended response headers</Description>
 		<Title>Jhoose Security</Title>


### PR DESCRIPTION
Make ICspProvider and IJhooseSecurityService services scoped instead of singleton to allow for unique dynamic nonce value per request.

Tested against the Demo site only after making some modifications to allow me to run it, some scripts didn't have nonce's in their script tags so violations were reported but all scripts that did have nonces where consistent and unique per request so it appears to be worked as expected.