### PR TITLE
Fix CSP policy syntax issues when the 'None' option is selected

### DIFF
--- a/.github/workflows/build-jhoose-security.yml
+++ b/.github/workflows/build-jhoose-security.yml
@@ -8,8 +8,8 @@ on:
   workflow_dispatch:
 
 env:
-  BUILD_NO: 2.4.1.${{ github.run_number }}  
-  BUILD_NO_PRE: 2.4.1-rc.${{ github.run_number }} 
+  BUILD_NO: 2.4.2.${{ github.run_number }}  
+  BUILD_NO_PRE: 2.4.2-rc.${{ github.run_number }} 
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -277,3 +277,4 @@ X-API-Key: ...
  |2.3.1| Bug fixes |
  |2.4.0| Added 'wasm-unsafe-eval' to the CSP Options<br/>Added missing options to default-src |
  |2.4.1| Make ICspProvider and IJhooseSecurityService request scoped so a unqiue dynamic nonce is generated per request |
+ |2.4.2| Ensure CSP policy header syntax is valid when using 'None' Option for any policy |

--- a/src/Jhoose.Security.Core/Jhoose.Security.Core.csproj
+++ b/src/Jhoose.Security.Core/Jhoose.Security.Core.csproj
@@ -9,7 +9,7 @@
 		<RepositoryUrl>https://github.com/andrewmarkham/contentsecuritypolicy</RepositoryUrl>
 		<ProjectUrl>https://github.com/andrewmarkham/contentsecuritypolicy</ProjectUrl>
 		-->
-		<Version>2.4.1.0</Version>
+		<Version>2.4.2.0</Version>
 		<Authors>Andrew Markham</Authors>
 		<Title>Jhoose Security Core</Title>
 		<Description>Core package used by the Jhoose Security module</Description>

--- a/src/Jhoose.Security.Core/Models/CSP/CspOptions.cs
+++ b/src/Jhoose.Security.Core/Models/CSP/CspOptions.cs
@@ -34,20 +34,22 @@ namespace Jhoose.Security.Core.Models.CSP
 
             if (this.None)
             {
-                sb.Append("'none'; ");
+                sb.Append("'none' ");
                 return sb.ToString();
             }
+            else
+            {
+                if (this.Wildcard) sb.Append("* ");
+                if (this.Self) sb.Append("'self' ");
 
-            if (this.Wildcard) sb.Append("* ");
-            if (this.Self) sb.Append("'self' ");
+                if (this.UnsafeEval) sb.Append("'unsafe-eval' ");
+                if (this.WasmUnsafeEval) sb.Append("'wasm-unsafe-eval' ");
+                if (this.UnsafeHashes) sb.Append("'unsafe-hashes' ");
+                if (this.UnsafeInline) sb.Append("'unsafe-inline' ");
+                if (this.StrictDynamic) sb.Append("'strict-dynamic' ");
 
-            if (this.UnsafeEval) sb.Append("'unsafe-eval' ");
-            if (this.WasmUnsafeEval) sb.Append("'wasm-unsafe-eval' ");
-            if (this.UnsafeHashes) sb.Append("'unsafe-hashes' ");
-            if (this.UnsafeInline) sb.Append("'unsafe-inline' ");
-            if (this.StrictDynamic) sb.Append("'strict-dynamic' ");
-
-            if (this.Nonce) sb.Append("'nonce-{0}' ");
+                if (this.Nonce) sb.Append("'nonce-{0}' ");
+            }
 
             return sb.ToString();
         }

--- a/src/Jhoose.Security.Core/Models/CSP/CspPolicy.cs
+++ b/src/Jhoose.Security.Core/Models/CSP/CspPolicy.cs
@@ -48,12 +48,18 @@ namespace Jhoose.Security.Core.Models.CSP
                 sb.AppendFormat($"{this.PolicyName} ");
 
                 sb.Append(this.Options?.ToString());
-                sb.Append(this.SchemaSource?.ToString());
-                sb.Append(this.SandboxOptions?.ToString());
 
-                var value = this.Value.Replace(Environment.NewLine, " ");
-
-                sb.AppendFormat($"{value}; ");
+                if (!this.Options?.None ?? false)
+                {
+                    sb.Append(this.SchemaSource?.ToString());
+                    sb.Append(this.SandboxOptions?.ToString());
+                    var value = this.Value.Replace(Environment.NewLine, " ");
+                    sb.AppendFormat($"{value}; ");
+                }
+                else
+                {
+                    sb.AppendFormat($"; ");
+                }
             }
 
             return sb.ToString();

--- a/src/Jhoose.Security/Jhoose.Security.csproj
+++ b/src/Jhoose.Security/Jhoose.Security.csproj
@@ -9,7 +9,7 @@
 		<RepositoryUrl>https://github.com/andrewmarkham/contentsecuritypolicy</RepositoryUrl>
 		<ProjectUrl>https://github.com/andrewmarkham/contentsecuritypolicy</ProjectUrl>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<Version>2.4.1.0</Version>
+		<Version>2.4.2.0</Version>
 		<Authors>Andrew Markham</Authors>
 		<Description>Interface to manage Content Security Policy and OWASP Recommended response headers</Description>
 		<Title>Jhoose Security</Title>

--- a/src/Jhoose.Security/src/components/csp/helpers.ts
+++ b/src/Jhoose.Security/src/components/csp/helpers.ts
@@ -26,7 +26,7 @@ export function getPolicyOptionsDisplay(policy: CspPolicy): string {
 export function getSchemaSourceDisplay(policy: CspPolicy): string {
     var v = "";
 
-    if (policy.schemaSource)
+    if (!policy.options.none && policy.schemaSource)
     {
         //schemaSource
         v = policy.schemaSource.http ? v+= "http: " : v;


### PR DESCRIPTION
- Ignore all other CSP Options except 'None' when 'None' is selected when building CSP string
- Ignore all CSP Schema and Sandbox options when 'None' Option is selected when building CSP string
- Ignore all Schema Options when 'None' options is selected when previewing policy in Admin UI
- Update version numbers and add release notes for V2.4.2