### PR TITLE
Strip CSP on 304 and non-html/non-js

### DIFF
--- a/src/Jhoose.Security/Middleware/ContentSecurityPolicyMiddleware.cs
+++ b/src/Jhoose.Security/Middleware/ContentSecurityPolicyMiddleware.cs
@@ -1,6 +1,8 @@
+using System.Net.Mime;
 using System.Threading.Tasks;
 using Jhoose.Security.Services;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Net.Http.Headers;
 
 namespace Jhoose.Security.Middleware
 {
@@ -19,6 +21,25 @@ namespace Jhoose.Security.Middleware
             {
                 securityService.AddContentSecurityPolicy(context.Response);
             }
+
+            context.Response.OnStarting(() =>
+            {
+                var response = context.Response;
+                // Strip on 304 Not Modified and non-HTML/JS responses
+                if (
+                    response.StatusCode == StatusCodes.Status304NotModified
+                    || response.Headers.TryGetValue(HeaderNames.ContentType, out var contentType)
+                        && !contentType.ToString().StartsWith(MediaTypeNames.Text.Html)
+                        && !contentType.ToString().StartsWith("text/javascript") // MediaTypeNames.Text.JavaScript is not available in .NET < 8
+                )
+                {
+                    response.Headers.Remove(HeaderNames.ContentSecurityPolicy);
+                    response.Headers.Remove(HeaderNames.ContentSecurityPolicyReportOnly);
+                }
+
+                return Task.CompletedTask;
+            });
+
             await _next(context);
         }
     }


### PR DESCRIPTION
Closes #138 

Got a bunch of errors when trying to setup the project (which I don't have time to fix right now) so this is a blindfix. Tried in a standalone middleware in a separate project though. 

Might be a good idea to add a test for this as well.