### PR TITLE
Scope the Castle.Core 5.2.1 reference to CMS13 builds

### DIFF
--- a/src/Jhoose.Security/Jhoose.Security.csproj
+++ b/src/Jhoose.Security/Jhoose.Security.csproj
@@ -144,6 +144,9 @@
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.2" />
         
         <PackageReference Include="System.IO.Packaging" Version="10.0.2" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(CMSVersion)' == 'CMS13' and '$(TargetFramework)' == 'net10.0'">
         <PackageReference Include="Castle.Core" Version="5.2.1" />
     </ItemGroup>
 


### PR DESCRIPTION
Fixes #206.

The `net10.0` ItemGroup in `Jhoose.Security.csproj` was conditioned on the target framework only, not on `CMSVersion`. Since CMS12 builds target `net8.0;net9.0;net10.0`, the CMS12 package built for `net10.0` picked up `Castle.Core 5.2.1` alongside CMS13.

Optimizely CMS 12 constrains `Castle.Core` to `[4.4.1, 5.0.0)` — `EPiServer.Shell` binds ``Castle.Core.Pair`2``, which was removed in 5.x — so an Optimizely CMS 12 site running on .NET 10 that installs `Jhoose.Security.Admin` resolves `Castle.Core 5.2.1` and dies at startup with a `TypeLoadException` in `ShellInitialization`.

This moves the `Castle.Core` reference into its own ItemGroup conditioned on `'$(CMSVersion)' == 'CMS13' and '$(TargetFramework)' == 'net10.0'`, matching the condition already used by the CMS13 ItemGroup above it. CMS13 is unaffected and keeps 5.2.1.

### Verification

Built and packed from this branch. Comparing the produced nuspec against the published `3.2.0.482`:

- `3.2.0.482` net10.0 group: declares `Castle.Core 5.2.1`
- this branch, net10.0 group: no `Castle.Core` entry
- all other dependency groups (net8.0, net9.0) unchanged

Also checked that `lib/net10.0/Jhoose.Security.dll` in `3.2.0.482` contains no references to any `Castle.*` type, so dropping the dependency for CMS12 is not removing something the assembly actually binds against.

Tested against an Optimizely CMS 12 / Commerce 14 solution on .NET 10, where the 5.2.1 dependency was otherwise being pinned back to 4.4.1 downstream to keep the site booting.